### PR TITLE
change array syntax to work with PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "illuminate/support": "4.*|5.*",
         "mailin-api/mailin-api-php": "dev-master"
     },

--- a/src/Vansteen/Sendinblue/SendinblueServiceProvider.php
+++ b/src/Vansteen/Sendinblue/SendinblueServiceProvider.php
@@ -29,9 +29,9 @@ class SendinblueServiceProvider extends ServiceProvider {
 		}
 		elseif ($version[0] == 5)
 		{
-			$this->publishes([
+			$this->publishes(array(
 				__DIR__.'/../../config/config.php' => config_path('sendinblue.php'),
-			]);
+			));
 		}
 	}
 


### PR DESCRIPTION
As Laravel 4.0 only requires PHP >= 5.3.7, and PHP 5.3 does not work with the short array syntax, this should be changed to ensure compatibility with Laravel 4.x.